### PR TITLE
Add finance to planning.budget and update doc and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 Sometimes, particularly in the case of Public Private Partnerships, contracts are financed using a range of instruments, including loans, grants, share issues and so-on.
 
-The financing extension provides a space to declare the finance arranged for a contract.
+The financing extension provides a space to declare:
 
-This is declared within the `contracts` section, based on an understanding that this information is generally only disclosed following the signature of a contract. This information can be updated over the lifetime of the contract.
+- the finance planned for the procedure
+- the finance arranged for a contract
+
+This is respectively declared within the `planning.budget` and `contracts` sections. This information can be updated over the lifetime of the contract.
 
 The finance building block includes:
 
@@ -22,6 +25,10 @@ The finance building block includes:
   * **notes** - space to provide more information on the rate
 
 This allows modelling of rates such as "LIBOR+1%".
+
+## Legal context
+
+In the European Union, this extension's fields correspond to [eForms BG-611 (Contract EU funds) and BG-61 (EU funds)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Codelists
 
@@ -90,6 +97,11 @@ The `financeCategory.csv` codelist is used to indicate (a) the rights attached t
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2020-04-17
+
+* Add the Finance array to `planning.budget`
+* Add the EU legal context
 
 ### 2019-03-20
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -13,6 +13,23 @@
         }
       }
     },
+    "Planning": {
+      "properties": {
+        "budget": {
+          "properties": {
+            "finance": {
+              "title": "Finance",
+              "description": "An array with details of each source of finance planned for this procedure.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Finance"
+              },
+              "uniqueItems": true
+            }
+          }
+        }
+      }
+    },
     "Finance": {
       "title": "Financing arrangements",
       "description": "This block can be used to model details of each of the parties financing a contract or project. Note: If the finance is syndicated, and all the parties to the syndication are known, this section may be further extended with an array of syndicate partners. No schema for this is currently provided.",


### PR DESCRIPTION
I didn't find any relevant section in the 2014/24/EU directive. The funding is mentioned in the annexes related to the information to include in forms.